### PR TITLE
Add missing NSLocationAlwaysUsageDescription to Info.plist.

### DIFF
--- a/ios/Peggy Meter/Info.plist
+++ b/ios/Peggy Meter/Info.plist
@@ -48,11 +48,13 @@
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Record health update usage for ML</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>Track location</string>
+	<string>Track location for ML</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Track location for ML</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Record mic usage data for ML</string>
 	<key>NSMotionUsageDescription</key>
-	<string>Track motion</string>
+	<string>Track motion for ML</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
NSLocationAlwaysUsageDescription is required by AppStore
for publishing the app.

Signed-off-by: Rustem Arzymbetov <rustem@rustems-mbp.lan>